### PR TITLE
Add libasound2 runtime dep and GHA build cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,6 +73,8 @@ jobs:
           push: true
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.docker-dir }}:latest
+          cache-from: type=gha,scope=${{ matrix.docker-dir }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.docker-dir }}
 
   custom-builds:
     name: Custom Docker Build

--- a/zeroclaw/Dockerfile
+++ b/zeroclaw/Dockerfile
@@ -49,7 +49,7 @@ RUN mkdir -p /zeroclaw-data/.zeroclaw /zeroclaw-data/workspace /zeroclaw-data/we
 FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        bash ca-certificates cron curl git \
+        bash ca-certificates cron curl git libasound2 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/zeroclaw /usr/local/bin/zeroclaw


### PR DESCRIPTION
## Summary
- Add `libasound2` to runtime stage — fixes `libasound.so.2` missing error for `voice-wake` feature
- Add GHA layer cache (`cache-from`/`cache-to`) scoped per image to speed up CI builds

## Test plan
- [ ] CI builds zeroclaw image successfully
- [ ] Container starts without shared library errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)