### PR TITLE
Share GHA build cache between branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,3 @@ jobs:
           file: ${{ matrix.docker-dir }}/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: false
-          cache-from: |
-            type=gha,scope=${{ matrix.docker-dir }}-${{ github.ref_name }}
-            type=gha,scope=${{ matrix.docker-dir }}-main
-          cache-to: type=gha,mode=max,scope=${{ matrix.docker-dir }}-${{ github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,7 @@ jobs:
           file: ${{ matrix.docker-dir }}/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: false
+          cache-from: |
+            type=gha,scope=${{ matrix.docker-dir }}-${{ github.ref_name }}
+            type=gha,scope=${{ matrix.docker-dir }}-main
+          cache-to: type=gha,mode=max,scope=${{ matrix.docker-dir }}-${{ github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
   docker-build:
     name: Test Docker Build
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-docker-images
     needs: setup-matrix
     if: needs.setup-matrix.outputs.matrix != '[]'
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
 
   docker-build:
     name: Docker Build
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-docker-images
     needs: setup-matrix
     if: needs.setup-matrix.outputs.matrix != '[]'
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,8 +73,10 @@ jobs:
           push: true
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.docker-dir }}:latest
-          cache-from: type=gha,scope=${{ matrix.docker-dir }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.docker-dir }}
+          cache-from: |
+            type=gha,scope=${{ matrix.docker-dir }}-${{ github.ref_name }}
+            type=gha,scope=${{ matrix.docker-dir }}-main
+          cache-to: type=gha,mode=max,scope=${{ matrix.docker-dir }}-${{ github.ref_name }}
 
   custom-builds:
     name: Custom Docker Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,10 +73,6 @@ jobs:
           push: true
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.docker-dir }}:latest
-          cache-from: |
-            type=gha,scope=${{ matrix.docker-dir }}-${{ github.ref_name }}
-            type=gha,scope=${{ matrix.docker-dir }}-main
-          cache-to: type=gha,mode=max,scope=${{ matrix.docker-dir }}-${{ github.ref_name }}
 
   custom-builds:
     name: Custom Docker Build


### PR DESCRIPTION
## Summary
- Scope cache keys by branch name (`<image>-<branch>`)
- Each build reads from its own branch cache first, then falls back to main
- PR branches benefit from main's cached layers on first build

## Test plan
- [ ] Verify PR CI build uses cache from main
- [ ] Verify main branch build still caches properly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)