### PR TITLE
Add gosu entrypoint, runtime tools, and hardening

### DIFF
--- a/zeroclaw/Dockerfile
+++ b/zeroclaw/Dockerfile
@@ -58,9 +58,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -m -d /zeroclaw-data -s /bin/bash zeroclaw
 
+ARG GOSU_VERSION=1.19
+RUN curl -fsSL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture)" \
+      -o /usr/local/bin/gosu && chmod +x /usr/local/bin/gosu && gosu --version
+
 COPY --from=builder /app/zeroclaw /usr/local/bin/zeroclaw
 COPY --from=builder /zeroclaw-data /zeroclaw-data
 COPY --from=builder /usr/share/zeroclaw /usr/share/zeroclaw
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 
 RUN chown -R zeroclaw:zeroclaw /zeroclaw-data /usr/share/zeroclaw \
     && (find /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin \
@@ -73,11 +78,10 @@ ENV HOME=/zeroclaw-data
 ENV ZEROCLAW_GATEWAY_PORT=42617
 
 WORKDIR /zeroclaw-data
-USER zeroclaw
 EXPOSE 42617
 
 HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=10s \
     CMD ["zeroclaw", "status", "--format=exit-code"]
 
-ENTRYPOINT ["zeroclaw"]
+ENTRYPOINT ["entrypoint.sh"]
 CMD ["daemon"]

--- a/zeroclaw/README.md
+++ b/zeroclaw/README.md
@@ -10,76 +10,87 @@ A custom ZeroClaw Docker image built with full features enabled, including all m
 
 ## Features
 
-Built with the following Cargo feature flags:
+<details>
+<summary>Cargo feature flags (click to expand)</summary>
 
-| Feature                    | Description                                       |
-| -------------------------- | ------------------------------------------------- |
-| `agent-runtime`            | Full agent loop, tools, and all standard channels |
-| `gateway`                  | Web dashboard UI and REST/WebSocket API           |
-| `whatsapp-web`             | WhatsApp via browser protocol (QR code pairing)   |
-| `channel-nostr`            | Nostr decentralized messaging                     |
-| `voice-wake`               | Voice wake word detection                         |
-| `rag-pdf`                  | PDF document RAG tool                             |
-| `channel-feishu`           | Feishu/Lark messaging                             |
-| `observability-prometheus` | Prometheus metrics endpoint                       |
-| `schema-export`            | Config schema export                              |
-| `tui-onboarding`           | Terminal UI onboarding                            |
+| Feature                    | Enabled | Description                                       |
+| -------------------------- | ------- | ------------------------------------------------- |
+| `agent-runtime`            | ✅      | Full agent loop, tools, and all standard channels |
+| `gateway`                  | ✅      | Web dashboard UI and REST/WebSocket API           |
+| `whatsapp-web`             | ✅      | WhatsApp via browser protocol (QR code pairing)   |
+| `channel-nostr`            | ✅      | Nostr decentralized messaging                     |
+| `voice-wake`               | ✅      | Voice wake word detection                         |
+| `rag-pdf`                  | ✅      | PDF document RAG tool                             |
+| `channel-feishu`           | ✅      | Feishu/Lark messaging                             |
+| `observability-prometheus` | ✅      | Prometheus metrics endpoint                       |
+| `schema-export`            | ✅      | Config schema export                              |
+| `tui-onboarding`           | ✅      | Terminal UI onboarding                            |
+
+</details>
 
 ## Channels
 
-All channels included via `agent-runtime` + extras:
+<details>
+<summary>All channels included via agent-runtime + extras (click to expand)</summary>
 
-| Channel            | Feature Flag             |
-| ------------------ | ------------------------ |
-| Email              | `channel-email`          |
-| Telegram           | `channel-telegram`       |
-| Slack              | `channel-slack`          |
-| Discord            | `channel-discord`        |
-| WhatsApp Cloud API | `channel-whatsapp-cloud` |
-| WhatsApp Web (QR)  | `whatsapp-web`           |
-| Signal             | `channel-signal`         |
-| Nostr              | `channel-nostr`          |
-| IRC                | `channel-irc`            |
-| iMessage           | `channel-imessage`       |
-| Bluesky            | `channel-bluesky`        |
-| Twitter/X          | `channel-twitter`        |
-| Reddit             | `channel-reddit`         |
-| Notion             | `channel-notion`         |
-| Mattermost         | `channel-mattermost`     |
-| DingTalk           | `channel-dingtalk`       |
-| QQ                 | `channel-qq`             |
-| WeCom              | `channel-wecom`          |
-| Lark/Feishu        | `channel-feishu`         |
-| LINE (LINQ)        | `channel-linq`           |
-| WATI               | `channel-wati`           |
-| Nextcloud          | `channel-nextcloud`      |
-| Webhook            | `channel-webhook`        |
-| Voice Call         | `channel-voice-call`     |
+| Channel            | Feature Flag             | Enabled |
+| ------------------ | ------------------------ | ------- |
+| Email              | `channel-email`          | ✅      |
+| Telegram           | `channel-telegram`       | ✅      |
+| Slack              | `channel-slack`          | ✅      |
+| Discord            | `channel-discord`        | ✅      |
+| WhatsApp Cloud API | `channel-whatsapp-cloud` | ✅      |
+| WhatsApp Web (QR)  | `whatsapp-web`           | ✅      |
+| Signal             | `channel-signal`         | ✅      |
+| Nostr              | `channel-nostr`          | ✅      |
+| IRC                | `channel-irc`            | ✅      |
+| iMessage           | `channel-imessage`       | ✅      |
+| Bluesky            | `channel-bluesky`        | ✅      |
+| Twitter/X          | `channel-twitter`        | ✅      |
+| Reddit             | `channel-reddit`         | ✅      |
+| Notion             | `channel-notion`         | ✅      |
+| Mattermost         | `channel-mattermost`     | ✅      |
+| DingTalk           | `channel-dingtalk`       | ✅      |
+| QQ                 | `channel-qq`             | ✅      |
+| WeCom              | `channel-wecom`          | ✅      |
+| Lark/Feishu        | `channel-feishu`         | ✅      |
+| LINE (LINQ)        | `channel-linq`           | ✅      |
+| WATI               | `channel-wati`           | ✅      |
+| Nextcloud          | `channel-nextcloud`      | ✅      |
+| Webhook            | `channel-webhook`        | ✅      |
+| Voice Call         | `channel-voice-call`     | ✅      |
+
+</details>
+
+## CLI Tools
+
+<details>
+<summary>Available tools for agent shell operations (click to expand)</summary>
+
+| Tool             | Enabled | Description             |
+| ---------------- | ------- | ----------------------- |
+| `bash`           | ✅      | Shell                   |
+| `curl`           | ✅      | HTTP client             |
+| `git`            | ✅      | Version control         |
+| `python3`        | ✅      | Python 3.11 interpreter |
+| `jq`             | ✅      | JSON processor          |
+| `vim`            | ✅      | Text editor             |
+| `wget`           | ✅      | File downloader         |
+| `zip` / `unzip`  | ✅      | Archive utilities       |
+| `openssh-client` | ✅      | SSH client              |
+| `rsync`          | ✅      | File sync               |
+| `tree`           | ✅      | Directory visualization |
+| `less`           | ✅      | Pager                   |
+| `procps`         | ✅      | `ps`, `top`, `free`     |
+| `net-tools`      | ✅      | `ifconfig`, `netstat`   |
+| `iputils-ping`   | ✅      | `ping`                  |
+| `file`           | ✅      | File type detection     |
+
+</details>
 
 ## User
 
 The container runs as a non-root user `zeroclaw` (created via `useradd`) with home directory `/zeroclaw-data`.
-
-## CLI Tools
-
-Available in the container for agent shell operations:
-
-- `bash`
-- `curl`
-- `git`
-- `python3`
-- `jq`
-- `vim`
-- `wget`
-- `zip` / `unzip`
-- `openssh-client`
-- `rsync`
-- `tree`
-- `less`
-- `procps` (`ps`, `top`, `free`)
-- `net-tools` (`ifconfig`, `netstat`)
-- `iputils-ping`
-- `file`
 
 ## Environment Variables
 
@@ -96,20 +107,27 @@ Available in the container for agent shell operations:
 services:
   zeroclaw:
     image: veerendra2/zeroclaw
+    container_name: zeroclaw
     restart: unless-stopped
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_RAW
     environment:
       NVIDIA_API_KEY: ${NVIDIA_API_KEY}
-      ZEROCLAW_ALLOW_PUBLIC_BIND: true
+      ZEROCLAW_ALLOW_PUBLIC_BIND: "true"
       ZEROCLAW_GATEWAY_HOST: "0.0.0.0"
+      ZEROCLAW_GATEWAY_PORT: "42617"
     ports:
-      - 42617:42617
+      - "42617:42617"
     volumes:
-      - zeroclaw_data:/zeroclaw-data
+      - /data/volumes/zeroclaw:/zeroclaw-data
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
     command:
       - daemon
-
-volumes:
-  zeroclaw_data:
+      - --host
+      - "0.0.0.0"
 ```
 
 ### Build Args
@@ -118,3 +136,4 @@ volumes:
 | ------------------------- | ------------------ | ------------------------------ |
 | `ZEROCLAW_VERSION`        | `v0.7.4`           | Git tag to build from          |
 | `ZEROCLAW_CARGO_FEATURES` | _(see Dockerfile)_ | Comma-separated Cargo features |
+| `GOSU_VERSION`            | `1.19`             | gosu version for entrypoint    |

--- a/zeroclaw/entrypoint.sh
+++ b/zeroclaw/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+if [ "$(id -u)" = "0" ]; then
+    mkdir -p /zeroclaw-data/.zeroclaw /zeroclaw-data/workspace
+    chown -R zeroclaw:zeroclaw /zeroclaw-data /usr/share/zeroclaw
+    exec gosu zeroclaw "$0" "$@"
+fi
+
+exec zeroclaw "$@"


### PR DESCRIPTION
## Summary
- Add `entrypoint.sh` that runs as root to fix bind mount permissions, then drops to `zeroclaw` user via gosu
- Install gosu 1.19 directly from GitHub releases (multi-arch compatible)
- Add runtime tools: python3, jq, vim, wget, zip/unzip, openssh-client, rsync, tree, less, procps, net-tools, iputils-ping, file
- Remove cron (setuid escalation vector) and pip (not needed at runtime)
- Strip all SUID/SGID bits from known binary paths
- Update README with collapsible sections for features/channels/tools and updated docker-compose example with cap_drop/cap_add

## Test plan
- [ ] Build the image successfully for amd64 and arm64
- [ ] Verify gosu drops privileges correctly (`whoami` returns `zeroclaw`)
- [ ] Verify bind mount permissions are fixed on startup
- [ ] Verify all runtime tools are available
- [ ] Verify no SUID binaries remain (`find /bin /sbin /usr -perm /6000`)
- [ ] Test with `--cap-drop=ALL --cap-add=NET_RAW`

🤖 Generated with [Claude Code](https://claude.com/claude-code)