### PR TITLE
feat(zeroclaw): add googleworkspace-cli (gws) to docker image

### DIFF
--- a/zeroclaw/Dockerfile
+++ b/zeroclaw/Dockerfile
@@ -19,6 +19,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update && apt-get install -y --no-install-recommends npm \
     && rm -rf /var/lib/apt/lists/*
 
+RUN npm install -g @googleworkspace/cli
+
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=zeroclaw-target,target=/app/target,sharing=locked \
@@ -79,6 +81,7 @@ RUN curl -fsSL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}
       -o /usr/local/bin/gosu && chmod +x /usr/local/bin/gosu && gosu --version
 
 COPY --from=builder /app/zeroclaw /usr/local/bin/zeroclaw
+COPY --from=api-generator /usr/local/bin/gws /usr/local/bin/gws
 COPY --from=builder /zeroclaw-data /zeroclaw-data
 COPY --from=builder /usr/share/zeroclaw /usr/share/zeroclaw
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/zeroclaw/Dockerfile
+++ b/zeroclaw/Dockerfile
@@ -74,7 +74,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         zip unzip openssh-client rsync vim \
         jq wget tree less procps net-tools iputils-ping file \
     && rm -rf /var/lib/apt/lists/* \
-    && useradd -m -d /zeroclaw-data -s /bin/bash zeroclaw
+    && groupadd -g 42617 zeroclaw \
+    && useradd -m -d /zeroclaw-data -u 42617 -g 42617 -s /bin/bash zeroclaw
 
 ARG GOSU_VERSION=1.19
 RUN curl -fsSL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture)" \

--- a/zeroclaw/README.md
+++ b/zeroclaw/README.md
@@ -94,7 +94,7 @@ A custom ZeroClaw Docker image built with full features enabled, including all m
 
 ## User
 
-The container runs as a non-root user `zeroclaw` (created via `useradd`) with home directory `/zeroclaw-data`.
+The container runs as a non-root user `zeroclaw` with **UID `42617` and GID `42617`** (created via `useradd`) to avoid permission collisions with standard host users (like `1000:1000`). Its home directory is `/zeroclaw-data`.
 
 ## Environment Variables
 

--- a/zeroclaw/README.md
+++ b/zeroclaw/README.md
@@ -76,6 +76,7 @@ A custom ZeroClaw Docker image built with full features enabled, including all m
 | `curl`           | ✅      | HTTP client             |
 | `git`            | ✅      | Version control         |
 | `python3`        | ✅      | Python 3.11 interpreter |
+| `gws`            | ✅      | Google Workspace CLI    |
 | `jq`             | ✅      | JSON processor          |
 | `vim`            | ✅      | Text editor             |
 | `wget`           | ✅      | File downloader         |


### PR DESCRIPTION
This PR adds the Google Workspace CLI (gws) to the ZeroClaw Docker image by installing it via npm in the builder stage and copying the binary to the runtime stage.