### PR TITLE
ci: separate custom builds into its own workflow

### DIFF
--- a/.github/workflows/custom-builds.yml
+++ b/.github/workflows/custom-builds.yml
@@ -1,0 +1,34 @@
+---
+name: Custom Builds Workflow
+
+on:
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+jobs:
+  custom-builds:
+    name: Custom Docker Build
+    runs-on: namespace-profile-docker-images
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Setup Qemu
+        uses: docker/setup-qemu-action@v4
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: amd64,arm64
+
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to Registry
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Run Script to Build and Push
+        run: |
+          .github/custom-builds.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,29 +74,4 @@ jobs:
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.docker-dir }}:latest
 
-  custom-builds:
-    name: Custom Docker Build
-    runs-on: namespace-profile-docker-images
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v6
 
-      - name: Setup Qemu
-        uses: docker/setup-qemu-action@v4
-        with:
-          image: tonistiigi/binfmt:latest
-          platforms: amd64,arm64
-
-      - name: Setup Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Login to Registry
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Run Script to Build and Push
-        run: |
-          .github/custom-builds.sh


### PR DESCRIPTION
This PR extracts the `custom-builds` job from `main.yml` into a new `custom-builds.yml` workflow file.

This allows you to trigger the standard Dockerfile builds and the custom builds separately via `workflow_dispatch` in the GitHub Actions UI.